### PR TITLE
Fix configuration section of README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,9 +31,9 @@ Vimeo client will first look for application variables, then environment variabl
 `config/dev.exs`
 ````elixir
 config :vimeo,
-  vimeo_client_id: "YOUR_CLIENT_ID",
-  vimeo_client_secret: "YOUR_CLIENT_SECRET",
-  vimeo_redirect_uri: "YOUR_ACCESS_TOKEN"
+  client_id: "YOUR_CLIENT_ID",
+  client_secret: "YOUR_CLIENT_SECRET",
+  access_token: "YOUR_ACCESS_TOKEN"
 ````
 
 `.env`


### PR DESCRIPTION
Hello. I've tried to configure vimeo.ex and found that there is an error in the configuration section of README.md. `Vimeo.configure` [use](https://github.com/lilfaf/vimeo.ex/blob/master/lib/vimeo.ex#L32) `get_env` with `:client_id` , but README.md says that I should use `:vimeo_client_id`. Also there was a typo with `vimeo_redirect_uri` instead of access token.

In this PR the configuration section of README.md has been fixed.